### PR TITLE
docs: fix

### DIFF
--- a/en/api/cli-swanlab-logout.md
+++ b/en/api/cli-swanlab-logout.md
@@ -1,4 +1,4 @@
-# swanlab 
+# swanlab logout
 
 ```bash
 swanlab logout

--- a/en/guide_cloud/community/online-support.md
+++ b/en/guide_cloud/community/online-support.md
@@ -1,28 +1,16 @@
 # Online Support
 
-## Social Media
-- **WeChat Official Account**:
+## 👋 Welcome to communicate with us
 
-<div align="center">
-<img src="/assets/wechat_public_account.jpg" width=300>
-</div>
+| WeChat Official Account | WeChat Group |
+| --- | ---  |
+| <div align="center"><img src="/assets/wechat_public_account.jpg" width=300></div> | <div align="center"><img src="/assets/wechat-QR-Code.png" width=300></div> |
 
-## Community
+| Feishu Group |
+| --- |
+| <div align="center"><img src="/assets/feishu-QR-Code.png" width=300></div> |
 
-- **WeChat Group**: Discuss SwanLab usage issues and share the latest AI technologies.
 
-<div align="center">
-<img src="/assets/wechat-QR-Code.png" width=300>
-</div>
-
-- **Feishu Group**: Our daily work communication is on Feishu, and the response in the Feishu group will be more timely. Scan the QR code below with the Feishu App:
-
-<div align="center">
-<img src="/assets/feishu-QR-Code.png" width=300>
-</div>
-
-## GitHub and Email
-- **[GitHub Issues](https://github.com/SwanHubX/SwanLab/issues)**: Report errors and issues encountered while using SwanLab.
-- **Email Support**: Report issues regarding SwanLab usage.
-  - Product: <contact@swanlab.cn>, <zeyi.lin@swanhub.co> (Product Manager's Email)
-  - Collaboration: <contact@swanlab.cn>, <shaohon_chen@115lab.club>
+## 📧 Contact us via Github or email
+- **GitHub Issues**：[link](https://github.com/SwanHubX/SwanLab/issues)，feedback on issues encountered when using SwanLab
+- **Email Support**：<contact@swanlab.cn>

--- a/zh/api/cli-swanlab-logout.md
+++ b/zh/api/cli-swanlab-logout.md
@@ -1,4 +1,4 @@
-# swanlab 
+# swanlab logout
 
 ```bash
 swanlab logout

--- a/zh/guide_cloud/community/online-support.md
+++ b/zh/guide_cloud/community/online-support.md
@@ -1,30 +1,16 @@
 # 在线支持
 
-## 社交媒体
-- **微信公众号**:
+## 👋 欢迎与我们交流
 
-<div align="center">
-<img src="/assets/wechat_public_account.jpg" width=300>
-</div>
+| 微信公众号 | 微信交流群 |
+| --- | ---  |
+| <div align="center"><img src="/assets/wechat_public_account.jpg" width=300></div> | <div align="center"><img src="/assets/wechat-QR-Code.png" width=300></div> |
 
-## 社群
-
-- **微信交流群**：交流使用SwanLab的问题、分享最新的AI技术。
-
-<div align="center">
-<img src="/assets/wechat-QR-Code.png" width=300>
-
-</div>
-
-- **飞书群**：我们的日常工作交流在飞书上，飞书群的回复会更及时。用飞书App扫描下方二维码即可：
-
-<div align="center">
-<img src="/assets/feishu-QR-Code.png" width=300>
-</div>
+| 飞书群 |
+| --- |
+| <div align="center"><img src="/assets/feishu-QR-Code.png" width=300></div> |
 
 
-## Github与邮件
-- **[GitHub Issues](https://github.com/SwanHubX/SwanLab/issues)**：反馈使用SwanLab时遇到的错误和问题
-- **电子邮件支持**：反馈关于使用SwanLab的问题
-  - 产品: <contact@swanlab.cn>, <zeyi.lin@swanhub.co>(产品经理邮箱)
-  - 合作: <contact@swanlab.cn>, <shaohon_chen@115lab.club>
+## 📧 用Github或邮件联系我们
+- **GitHub Issues**：[链接](https://github.com/SwanHubX/SwanLab/issues)，反馈使用SwanLab时遇到的错误和问题
+- **电子邮件支持**：<contact@swanlab.cn>


### PR DESCRIPTION
This pull request includes changes to the documentation for both English and Chinese versions, focusing on logout commands and online support sections. The most important changes include updating the logout command documentation and restructuring the online support sections to improve clarity and accessibility.

Changes to logout command documentation:

* [`en/api/cli-swanlab-logout.md`](diffhunk://#diff-30b3f5160a1f80ddffc524932f2930bc25eaaf9de7ee26de77469863ca10f24dL1-R1): Corrected the title from "swanlab" to "swanlab logout".
* [`zh/api/cli-swanlab-logout.md`](diffhunk://#diff-752cd9d92b7715b232f7466f3dfafb025aaf23c9f348a8031c95116ee895726cL1-R1): Corrected the title from "swanlab" to "swanlab logout".

Improvements to online support sections:

* [`en/guide_cloud/community/online-support.md`](diffhunk://#diff-e07dbc496887827d31e9492c941a2996ab0d016018143ea1c7b4027b614df574L3-R16): Updated the section to include a more welcoming introduction and restructured the presentation of contact methods, including WeChat, Feishu, GitHub, and email support.
* [`zh/guide_cloud/community/online-support.md`](diffhunk://#diff-2a1875c5d2a9890c64d0f0e10f232d95a21ba9c963db29fedce6fa6d7e6ff476L3-R16): Updated the section to include a more welcoming introduction and restructured the presentation of contact methods, including WeChat, Feishu, GitHub, and email support.