### PR TITLE
fix: api convert

### DIFF
--- a/en/api/cli-swanlab-login.md
+++ b/en/api/cli-swanlab-login.md
@@ -12,7 +12,7 @@ swanlab login [OPTIONS]
 
 Log in to your SwanLab account to synchronize experiments to the cloud.
 
-After running the following command, if it's your first login, you will be prompted to fill in your [API_KEY](#):
+After running the following command, if it's your first login, you will be prompted to fill in your [API_KEY](https://swanlab.cn/settings):
 
 ```bash
 swanlab login

--- a/en/examples/fashionmnist.md
+++ b/en/examples/fashionmnist.md
@@ -263,7 +263,7 @@ Switching is very simple; just modify the `model` parameter in the `config` to t
     )
 ```
 
-- How does `config` work? 👉 [Set Experiment Configuration](/zh/guide_cloud/experiment_track/set-experiment-config)
+- How does `config` work? 👉 [Set Experiment Configuration](/guide_cloud/experiment_track/set-experiment-config)
 
 ## Demonstration of Results
 

--- a/en/guide_cloud/experiment_track/create-experiment.md
+++ b/en/guide_cloud/experiment_track/create-experiment.md
@@ -53,7 +53,7 @@ The dictionary you pass in `config` will be saved and used for subsequent experi
 swanlab.config={"epochs": 20, "learning_rate": 1e-4, "batch_size": 32, "model_type": "CNN"}
 ```
 
-For more information on how to configure experiments, see [Set Experiment Configuration](/zh/guide_cloud/experiment_track/set-experiment-config.md).
+For more information on how to configure experiments, see [Set Experiment Configuration](/guide_cloud/experiment_track/set-experiment-config.md).
 
 <br>
 

--- a/en/guide_cloud/experiment_track/log-experiment-metric.md
+++ b/en/guide_cloud/experiment_track/log-experiment-metric.md
@@ -19,7 +19,7 @@ for epoch in range(num_epochs):
 
 When `swanlab.log` is used for logging, it will aggregate the dictionary `{metric name: metric}` to a unified location based on the metric name.
 
-⚠️It is important to note that the value in `swanlab.log({key: value})` must be of type `int` / `float` / `BaseType` (if a `str` type is passed, it will first be attempted to be converted to `float`, and if the conversion fails, an error will be reported). The `BaseType` type mainly refers to multimedia data. For details, please refer to [Log Multimedia Data](/zh/guide_cloud/experiment_track/log-media.md).
+⚠️It is important to note that the value in `swanlab.log({key: value})` must be of type `int` / `float` / `BaseType` (if a `str` type is passed, it will first be attempted to be converted to `float`, and if the conversion fails, an error will be reported). The `BaseType` type mainly refers to multimedia data. For details, please refer to [Log Multimedia Data](/guide_cloud/experiment_track/log-media.md).
 
 Each time a record is made, a `step` is assigned to that record. By default, `step` starts from 0 and, with each subsequent logging under the same metric name, `step` equals the maximum `step` of historical records for that metric name + 1. For example:
 

--- a/zh/api/api-index.md
+++ b/zh/api/api-index.md
@@ -1,18 +1,19 @@
 # API文档
 
 ## CLI
-- [swanlab watch](/zh/api/cli-swanlab-watch.md): 启动离线实验看板
-- [swanlab login](/zh/api/cli-swanlab-login.md): 登录SwanLab
-- [swanlab logout](/zh/api/cli-swanlab-logout.md): 登出SwanLab
-- [swanlab convert](/zh/api/cli-swanlab-convert.md): 将外部日志转换为SwanLab项目
+- [swanlab watch](/api/cli-swanlab-watch.md): 启动离线实验看板
+- [swanlab login](/api/cli-swanlab-login.md): 登录SwanLab
+- [swanlab logout](/api/cli-swanlab-logout.md): 登出SwanLab
+- [swanlab convert](/api/cli-swanlab-convert.md): 将外部日志转换为SwanLab项目
 
 ## Python SDK
-- [init](/zh/api/py-init.md)
-- [login](/zh/api/py-login.md)
-- [Image](/zh/api/py-Image.md)
-- [Audio](/zh/api/py-Audio.md)
-- [Text](/zh/api/py-Text.md)
+- [init](/api/py-init.md)
+- [login](/api/py-login.md)
+- [Image](/api/py-Image.md)
+- [Audio](/api/py-Audio.md)
+- [Text](/api/py-Text.md)
 
 ## 其他
-- [环境变量](/zh/api/environment-variable.md)
+- [环境变量](/api/environment-variable.md)
 
+    

--- a/zh/api/cli-swanlab-login.md
+++ b/zh/api/cli-swanlab-login.md
@@ -12,7 +12,7 @@ swanlab login [OPTIONS]
 
 登录SwanLab账号，以同步实验到云端。
 
-执行下面的命令后，如果第一次登录，会让你填写[API_KEY](#)：
+执行下面的命令后，如果第一次登录，会让你填写[API_KEY](https://swanlab.cn/settings)：
 
 ```bash
 swanlab login


### PR DESCRIPTION
This pull request includes several documentation updates to correct URLs and improve clarity. The most important changes include updating links to the correct paths in multiple files.

Documentation updates:

* [`en/api/cli-swanlab-login.md`](diffhunk://#diff-c8ff8d3744027e35d1b7506cce330c0a4254e509a28f9238e1be8fdeb0179e24L15-R15): Updated the link for `API_KEY` to point to the correct settings page.
* [`en/examples/fashionmnist.md`](diffhunk://#diff-9ffc343c103e6c3e3d53076a8fae7f9ebb57171401f9bc3ffc34368cff667a35L266-R266): Corrected the link for setting experiment configuration to the correct path.
* [`en/guide_cloud/experiment_track/create-experiment.md`](diffhunk://#diff-941027491a25feba3f5fb62f62ee54aea7d30ff61ca29c589002c8a4de3df694L56-R56): Corrected the link for setting experiment configuration to the correct path.
* [`en/guide_cloud/experiment_track/log-experiment-metric.md`](diffhunk://#diff-bbd5c7bd19c495ca2705fd13857eb923510b233cd314ff2cab1172a0b17ec55fL22-R22): Updated the link for logging multimedia data to the correct path.
* [`zh/api/api-index.md`](diffhunk://#diff-bf35be1b67c546fd60c6c48c0f4db8ac6fb01934d05be7228992d6bb54a38e05L4-R18): Updated multiple links to remove the `/zh` prefix for consistency.