### PR TITLE
Update the command line for converting the tensorboard.

### DIFF
--- a/en/guide_cloud/integration/integration-tensorboard.md
+++ b/en/guide_cloud/integration/integration-tensorboard.md
@@ -121,7 +121,7 @@ for epoch in range(2, epochs):
 ### 2.1 Method 1: Command Line Conversion
 
 ```bash
-swanlab convert -t tensorboard -tb_logdir [TFEVENT_LOGDIR]
+swanlab convert -t tensorboard --tb_logdir [TFEVENT_LOGDIR]
 ```
 
 Here, `[TFEVENT_LOGDIR]` refers to the path of the log files generated when you previously recorded experiments with Tensorboard.

--- a/zh/guide_cloud/integration/integration-tensorboard.md
+++ b/zh/guide_cloud/integration/integration-tensorboard.md
@@ -121,7 +121,7 @@ for epoch in range(2, epochs):
 ### 2.1 方式一：命令行转换
 
 ```bash
-swanlab convert -t tensorboard -tb_logdir [TFEVENT_LOGDIR]
+swanlab convert -t tensorboard --tb_logdir [TFEVENT_LOGDIR]
 ```
 
 这里的`[TFEVENT_LOGDIR]`是指你先前用Tensorboard记录实验时，生成的日志文件路径。


### PR DESCRIPTION
In the official documentation, there is an issue with the conversion command for TensorBoard. There should be two dashes before logdir.
