### PR TITLE
api update

### DIFF
--- a/.vitepress/en.ts
+++ b/.vitepress/en.ts
@@ -293,6 +293,7 @@ function sidebarAPI(): DefaultTheme.SidebarItem[] {
         { text: 'Audio', link: 'py-Audio' },
         { text: 'Text', link: 'py-Text' },
       ]},
+      { text: 'run', link: 'py-run' },
       { text: 'login', link: 'py-login' },
       { text: 'integration', link: 'py-integration' },
       { text: 'converter', link: 'py-converter' },

--- a/.vitepress/zh.ts
+++ b/.vitepress/zh.ts
@@ -298,6 +298,7 @@ function sidebarAPI(): DefaultTheme.SidebarItem[] {
         { text: 'Audio', link: 'py-Audio' },
         { text: 'Text', link: 'py-Text' },
       ]},
+      { text: 'run', link: 'py-run' },
       { text: 'login', link: 'py-login' },
       { text: 'integration', link: 'py-integration' },
       { text: 'converter', link: 'py-converter' },

--- a/en/api/py-init.md
+++ b/en/api/py-init.md
@@ -28,6 +28,8 @@ init(
 | mode          | (str) Sets the mode for creating the SwanLab experiment. Options include "cloud", "local", "disabled". Defaults to "cloud". <br> `cloud`: Uploads the experiment to the cloud. <br> `local`: Does not upload to the cloud but records the experiment locally. <br> `disabled`: Does not upload or record. |
 | load          | (str) Path to the configuration file to load. Supports yaml and json files. |
 | public        | (bool) Sets the visibility of the SwanLab project created directly by code. Defaults to False, i.e., private. |
+| name       | (str) The same as `experiment_name`. |
+| notes       | (str) The same as `description`. |
 
 ## Introduction
 

--- a/en/api/py-integration.md
+++ b/en/api/py-integration.md
@@ -1,15 +1,17 @@
 # swanlab.integration
 
+[Source code](https://github.com/SwanHubX/SwanLab/tree/main/swanlab/integration)
+
 API for integrating SwanLab with external projects.
 
-- [swanlab.integration.pytorch_lightning](/en/guide_cloud/integration/integration-pytorch-lightning.md)
-- [swanlab.integration.huggingface](/en/guide_cloud/integration/integration-huggingface-transformers.md)
-- [swanlab.integration.accelerate](/en/guide_cloud/integration/integration-huggingface-accelerate.md)
-- [swanlab.integration.ultralytics](/en/guide_cloud/integration/integration-ultralytics.md)
-- [swanlab.integration.fastai](/en/guide_cloud/integration/integration-fastai.md)
-- [swanlab.integration.openai](/en/guide_cloud/integration/integration-openai.md)
-- [swanlab.integration.zhipuai](/en/guide_cloud/integration/integration-zhipuai.md)
-- [swanlab.integration.sb3](/en/guide_cloud/integration/integration-sb3.md)
-- [swanlab.integration.keras](/en/guide_cloud/integration/integration-keras.md)
-- [swanlab.integration.mmengine](/en/guide_cloud/integration/integration-mmengine.md)
-- [swanlab.integration.torchtune](/en/guide_cloud/integration/integration-pytorch-torchtune.md)
+- [swanlab.integration.accelerate](/guide_cloud/integration/integration-huggingface-accelerate.md)
+- [swanlab.integration.fastai](/guide_cloud/integration/integration-fastai.md)
+- [swanlab.integration.keras](/guide_cloud/integration/integration-keras.md)
+- [swanlab.integration.lightgbm](/guide_cloud/integration/integration-lightgbm.md)
+- [swanlab.integration.mmengine](/guide_cloud/integration/integration-mmengine.md)
+- [swanlab.integration.pytorch_lightning](/guide_cloud/integration/integration-pytorch-lightning.md)
+- [swanlab.integration.sb3](/guide_cloud/integration/integration-sb3.md)
+- [swanlab.integration.torchtune](/guide_cloud/integration/integration-pytorch-torchtune.md)
+- [swanlab.integration.transformers](/guide_cloud/integration/integration-huggingface-transformers.md)
+- [swanlab.integration.ultralytics](/guide_cloud/integration/integration-ultralytics.md)
+- [swanlab.integration.xgboost](/guide_cloud/integration/integration-xgboost.md)

--- a/en/api/py-log.md
+++ b/en/api/py-log.md
@@ -6,6 +6,7 @@
 log(
     data: Dict[str, DataType],
     step: int = None,
+    print_to_console: bool = False,
 )
 ```
 
@@ -13,7 +14,7 @@ log(
 |-----------|-------------|
 | data      | (Dict[str, DataType]) Required. Pass in a dictionary of key-value pairs, where the key is the metric name and the value is the metric value. The value supports int, float, types that can be converted by float(), or any `BaseType` type. |
 | step      | (int) Optional. This parameter sets the step number for the data. If step is not set, it will start from 0 and increment by 1 for each subsequent step. |
-| print_to_console | (bool) Optional, default is False. When set to True, the key and value of data will be printed to the terminal in dictionary format. |`
+| print_to_console | (bool) Optional, default is False. When set to True, the key and value of data will be printed to the terminal in dictionary format. |
 
 ## Introduction
 
@@ -26,6 +27,20 @@ swanlab.log({"acc": 0.9, "loss":0.1462})
 ```
 
 In addition to scalars, `swanlab.log` supports logging multimedia data, including images, audio, text, etc., and has a good display effect in the UI.
+
+## Print the Passed Dictionary
+
+`swanlab.log` supports printing the `key` and `value` of the passed `data` to the terminal. By default, this feature is disabled. To enable printing, you need to set `print_to_console=True`.
+
+```python
+swanlab.log({"acc": 0.9, "loss": 0.1462}, print_to_console=True)
+```
+
+Alternatively, you can also print it in this way:
+
+```python
+print(swanlab.log({"acc": 0.9, "loss": 0.1462}))
+```
 
 ## More Usage
 

--- a/en/api/py-run.md
+++ b/en/api/py-run.md
@@ -1,0 +1,32 @@
+# run
+
+The term "run" refers to the `SwanLabRun` object returned by `swanlab.init()`. This section introduces some of the methods available for the run.  
+(Updating gradually...)
+
+## public
+
+The `public` attribute stores some public information about the `SwanLabRun`, including:
+- `project_name`: The name of the project
+- `version`: The version
+- `run_id`: The experiment ID
+- `swanlog_dir`: The path to the swanlog directory
+- `run_dir`: The path to the run directory
+- `cloud`: Cloud-related information
+    - `project_name`: The project name (only valid in cloud mode)
+    - `project_url`: The URL of the project in the cloud (only valid in cloud mode)
+    - `experiment_name`: The experiment name (only valid in cloud mode)
+    - `experiment_url`: The URL of the experiment in the cloud (only valid in cloud mode)
+
+To retrieve the `public` information as a dictionary:
+
+```python
+import swanlab
+run = swanlab.init()
+print(run.public.json())
+```
+
+For example, if you want to get the experiment's URL, you can do this:
+
+```python
+print(run.public.cloud.experiment_url)
+```

--- a/zh/api/py-init.md
+++ b/zh/api/py-init.md
@@ -28,6 +28,8 @@ init(
 | mode       | (str) 设置swanlab实验创建的模式，可选"cloud"、"local"、"disabled"，默认设置为"cloud"。<br>`cloud`：将实验上传到云端。<br>`local`：不上传到云端，但会记录实验到本地。<br>`disabled`：不上传也不记录。|
 | load       | (str) 加载的配置文件路径，支持yaml和json文件。|
 | public       | (bool) 设置使用代码直接创建SwanLab项目的可见性，默认为False即私有。|
+| name       | (str) 与experiment_name效果一致，优先级低于experiment_name。|
+| notes       | (str) 与description效果一致，优先级低于description。|
 
 ## 介绍
 

--- a/zh/api/py-integration.md
+++ b/zh/api/py-integration.md
@@ -1,15 +1,17 @@
 # swanlab.integration
 
+[源代码](https://github.com/SwanHubX/SwanLab/tree/main/swanlab/integration)
+
 SwanLab与外部项目的集成API。
 
-- [swanlab.integration.pytorch_lightning](/guide_cloud/integration/integration-pytorch-lightning.md)
-- [swanlab.integration.huggingface](/guide_cloud/integration/integration-huggingface-transformers.md)
 - [swanlab.integration.accelerate](/guide_cloud/integration/integration-huggingface-accelerate.md)
-- [swanlab.integration.ultralytics](/guide_cloud/integration/integration-ultralytics.md)
 - [swanlab.integration.fastai](/guide_cloud/integration/integration-fastai.md)
-- [swanlab.integration.openai](/guide_cloud/integration/integration-openai.md)
-- [swanlab.integration.zhipuai](/guide_cloud/integration/integration-zhipuai.md)
-- [swanlab.integration.sb3](/guide_cloud/integration/integration-sb3.md)
 - [swanlab.integration.keras](/guide_cloud/integration/integration-keras.md)
+- [swanlab.integration.lightgbm](/guide_cloud/integration/integration-lightgbm.md)
 - [swanlab.integration.mmengine](/guide_cloud/integration/integration-mmengine.md)
+- [swanlab.integration.pytorch_lightning](/guide_cloud/integration/integration-pytorch-lightning.md)
+- [swanlab.integration.sb3](/guide_cloud/integration/integration-sb3.md)
 - [swanlab.integration.torchtune](/guide_cloud/integration/integration-pytorch-torchtune.md)
+- [swanlab.integration.transformers](/guide_cloud/integration/integration-huggingface-transformers.md)
+- [swanlab.integration.ultralytics](/guide_cloud/integration/integration-ultralytics.md)
+- [swanlab.integration.xgboost](/guide_cloud/integration/integration-xgboost.md)

--- a/zh/api/py-log.md
+++ b/zh/api/py-log.md
@@ -6,6 +6,7 @@
 log(
     data: Dict[str, DataType],
     step: int = None,
+    print_to_console: bool = False,
 )
 ```
 
@@ -26,6 +27,20 @@ swanlab.log({"acc": 0.9, "loss":0.1462})
 ```
 
 除了标量以外，`swanlab.log`支持记录多媒体数据，包括图像、音频、文本等，并在UI上有很好的显示效果。
+
+## 打印传入的字典
+
+`swanlab.log`支持打印传入的`data`的`key`和`value`到终端，默认情况下不打印。要开启打印的话，需要设置`print_to_console=True`。
+
+```python
+swanlab.log({"acc": 0.9, "loss":0.1462}, print_to_console=True)
+```
+
+当然，你也可以用这种方式打印：
+
+```python
+print(swanlab.log({"acc": 0.9, "loss":0.1462}))
+```
 
 ## 更多用法
 

--- a/zh/api/py-run.md
+++ b/zh/api/py-run.md
@@ -1,0 +1,32 @@
+# run
+
+run 指的是 `swanlab.init()` 返回的 `SwanLabRun` 对象，这里介绍run具有的一些方法。  
+(逐步更新中...)
+
+## public
+
+public存储了SwanLabRun的一些公共信息，包括：
+- `project_name`: 项目名称
+- `version`: 版本
+- `run_id`: 实验ID
+- `swanlog_dir`: swanlog日志目录的路径
+- `run_dir`: 运行目录的路径
+- `cloud`: 云端信息
+    - `project_name`: 项目名称（仅在cloud模式时有效）
+    - `project_url`: 项目在云端的URL（仅在cloud模式时有效）
+    - `experiment_name`: 实验名称（仅在cloud模式时有效）
+    - `experiment_url`: 实验在云端的URL（仅在cloud模式时有效）
+
+以字典形式获取public信息：
+
+```python
+import swanlab
+run = swanlab.init()
+print(run.public.json())
+```
+
+比如，你想要获取实验的URL，可以这样：
+
+```python
+print(run.public.cloud.experiment_url)
+```


### PR DESCRIPTION
This pull request includes updates to the documentation for the SwanLab project, including new attributes and methods, additional links, and improvements to existing content. The most important changes are summarized below:

### Documentation Enhancements:

* Added new attributes `name` and `notes` to the `init` function documentation in both English and Chinese versions (`en/api/py-init.md`, `zh/api/py-init.md`). [[1]](diffhunk://#diff-861e90c1dd210bc847eeb1b559f5700bfb604c5a5d5cb74e680418118397184eR31-R32) [[2]](diffhunk://#diff-9501bcbe0aa33ae17e7776eda930239037c48a8aa1802f44524cdfda1da1b0ccR31-R32)
* Introduced a new section for the `run` object, detailing available methods and public attributes in both English and Chinese versions (`en/api/py-run.md`, `zh/api/py-run.md`). [[1]](diffhunk://#diff-b3dccd5b3d5ba96353cc36f31e6eee773fb206f51de0f1e91dae65820d11cacdR1-R32) [[2]](diffhunk://#diff-1a06c5bd73787cb88d9be3e6dc54af94d1a54fc32a8c2c9f54df0193f3404dbeR1-R32)

### Sidebar Updates:

* Added a new sidebar link for `run` in both English and Chinese sidebar configuration files (`.vitepress/en.ts`, `.vitepress/zh.ts`). [[1]](diffhunk://#diff-c2d80e96c7e2fd8983a1005504b4aca41bad1d752a43a519a92b9f376fa1600bR296) [[2]](diffhunk://#diff-6573d8112c16d18f495e4b444fdc7b65efce947b3f85831a368ae89b84a58854R301)

### Integration Links:

* Updated the integration links and added a source code link in both English and Chinese integration documentation (`en/api/py-integration.md`, `zh/api/py-integration.md`). [[1]](diffhunk://#diff-700dea23a2f441057c01b627d0a738fa59846bf72de7ccb87d0186a4e0aa2b6bR3-R17) [[2]](diffhunk://#diff-2f6471bbe2399cc2de323379b9cc998a15d100bd2bef2b29169fe2193e43e208R3-R17)

### Logging Functionality:

* Added documentation for the `print_to_console` parameter in the `log` function and provided examples of its usage in both English and Chinese versions (`en/api/py-log.md`, `zh/api/py-log.md`). [[1]](diffhunk://#diff-33fa597bd9c0f0398b1ddb246d2c477e213b41a6800b308dae95c773b16a3cafR9-R17) [[2]](diffhunk://#diff-3da3382ae1c571a5187d0509b4f10a3534be946eecd19bbec37aba4511b5fa04R9) [[3]](diffhunk://#diff-33fa597bd9c0f0398b1ddb246d2c477e213b41a6800b308dae95c773b16a3cafR31-R44) [[4]](diffhunk://#diff-3da3382ae1c571a5187d0509b4f10a3534be946eecd19bbec37aba4511b5fa04R31-R44)