### PR TITLE
Update integration-verl.md

### DIFF
--- a/zh/guide_cloud/integration/integration-verl.md
+++ b/zh/guide_cloud/integration/integration-verl.md
@@ -133,6 +133,6 @@ PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
  data.train_files=$HOME/data/gsm8k/train.parquet \
  data.val_files=$HOME/data/gsm8k/test.parquet \
  trainer.logger=['console','swanlab'] \
- val_generations_to_log_to_wandb=1 \
+ +val_generations_to_log_to_wandb=1 \
  ...
 ```


### PR DESCRIPTION
fix bug:

Could not override 'val_generations_to_log_to_wandb'. To append to your config use +val_generations_to_log_to_wandb=1 Key 'val_generations_to_log_to_wandb' is not in struct
    full_key: val_generations_to_log_to_wandb
    object_type=dict

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.