### PR TITLE
docs(api): delete experiment & project

### DIFF
--- a/en/api/py-openapi.md
+++ b/en/api/py-openapi.md
@@ -330,6 +330,34 @@ my_api.get_experiment(project="project1", exp_id="cuid1").data.user["username"]
 
 <br>
 
+#### `delete_experiment`
+
+Delete an experiment.
+
+**Method Parameters**
+
+| Parameter  | Type   | Description                                                                                   |
+| ---        | ---    | ---                                                                                           |
+| `project`  | `str`  | Project name                                                                                  |
+| `exp_id`   | `str`  | Experiment CUID, unique identifier, can be obtained via `list_experiments` or from the "Environment" tab on the web |
+| `username` | `str`  | Username of the workspace, defaults to the current user                                       |
+
+**Returns**
+
+`data` `(dict)`: Empty dictionary, indicating the delete operation was successful
+
+**Example**
+
+::: code-group
+
+```python [Delete an experiment]
+my_api.delete_experiment(project="project1", exp_id="cuid1")
+```
+
+:::
+
+<br>
+
 #### `get_summary`
 
 Retrieve the summary information of an experiment, including the final value and min/max of tracked metrics and their corresponding steps.
@@ -449,3 +477,32 @@ my_api.list_projects().data
 ```
 
 :::
+
+<br>
+
+#### `delete_project`
+
+Delete a project.
+
+**Method Parameters**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `project` | `str` | Project name |
+| `username` | `str` | Username of the workspace, defaults to the current user
+
+**Returns**
+
+`data` `(dict)`: Empty dictionary, indicating the delete operation was successful
+
+**Example**
+
+::: code-group
+
+```python [Delete a project]
+my_api.delete_project(project="project1")
+```
+
+:::
+
+<br>

--- a/zh/api/py-openapi.md
+++ b/zh/api/py-openapi.md
@@ -331,6 +331,32 @@ my_api.get_experiment(project="project1", exp_id="cuid1").data.user["username"]
 
 <br>
 
+#### `delete_experiment`
+
+删除一个实验
+
+**方法参数**
+| 参数 | 类型 | 描述 |
+| --- | --- | --- |
+| `project` | `str` | 项目名 |
+| `exp_id` | `str` | 实验CUID, 唯一标识符, 可通过`list_experiments`获取, 也可在云端版实验"环境"标签页查看 |
+| `username` | `str` | 工作空间名, 默认为用户个人空间 |
+
+**返回值**
+`data` `(dict)`: 空字典, 仅表示删除操作成功
+
+**示例**
+
+::: code-group
+
+```python [删除实验]
+my_api.delete_experiment(project="project1", exp_id="cuid1")
+```
+
+:::
+
+<br>
+
 #### `get_summary`
 
 获取一个实验的概要信息, 包含实验跟踪指标的最终值和最大最小值, 以及其对应的步数
@@ -450,3 +476,30 @@ my_api.list_projects().data
 ```
 
 :::
+
+#### `delete_project`
+
+删除一个项目
+
+**方法参数**
+
+| 参数 | 类型 | 描述 |
+| --- | --- | --- |
+| `project` | `str` | 项目名 |
+| `username` | `str` | 工作空间名, 默认为用户个人空间 |
+
+**返回值**
+
+`data` `(dict)`: 空字典, 仅表示删除操作成功
+
+**示例**
+
+::: code-group
+
+```python [删除项目]
+my_api.delete_project(project="project1")
+```
+
+:::
+
+<br>


### PR DESCRIPTION
## Description

Add DELETE APIs for projects and experiments

### Delete Project

```python
res = api.delete_project(
    username=username,
    project=project
)
```
res.code = 204 if project was deleted successfully

### Delete Experiment

```python
res = api.delete_experiment(
    username=username,
    project=project,
    exp_id=cuid
)
```
res.code = 204 if experiment was deleted successfully

---

Relate https://github.com/SwanHubX/SwanLab/pull/1138