### PR TITLE
feat: add maxMetricsPerCopy configuration documentation

### DIFF
--- a/en/self_host/kubernetes/configuration.md
+++ b/en/self_host/kubernetes/configuration.md
@@ -10,6 +10,7 @@
 | `global.clusterDomain`         | string | `cluster.local` | Kubernetes cluster domain                                                                                                                                                                                                                                                         |
 | `global.podAntiAffinityPreset` | string | `soft`          | Pod anti-affinity strategy: `soft` (try to spread) / `hard` (force spread) / `none` (no setting)                                                                                                                                                                                  |
 | `global.settings.host`         | string | `""`            | Login host address. After modification, the API Key login address displayed in the frontend application will change accordingly (does not affect the actual backend service address). If you use SSO features, this is recommended to be set to the external URL of your gateway. |
+| `global.settings.limits.maxMetricsPerCopy` | number | `20000` | Maximum number of metrics (columns) allowed per experiment copy operation, used to limit resource usage and prevent performance or storage issues caused by overly large experiments |
 
 ### Pod Anti-Affinity
 

--- a/zh/self_host/kubernetes/configuration.md
+++ b/zh/self_host/kubernetes/configuration.md
@@ -10,6 +10,7 @@
 | `global.clusterDomain`         | string | `cluster.local` | Kubernetes 集群域名                                                                                                                            |
 | `global.podAntiAffinityPreset` | string | `soft`          | Pod 反亲和策略：`soft`（尽量分散）/ `hard`（强制分散）/ `none`（不设置）                                                                       |
 | `global.settings.host`         | string | `""`            | 登录主机地址，修改后前端应用中显示的 API Key 登录地址会随之变化（不影响实际后端服务地址）。若使用 SSO 功能，强烈建议将其配置为网关的外部 URL。 |
+| `global.settings.limits.maxMetricsPerCopy` | number | `20000` | 单次复制实验时允许的最大指标（metrics/columns）数量，用于限制复制操作的资源上限，防止单实验数据规模过大导致性能或存储压力 |
 
 ### Pod 反亲和性
 


### PR DESCRIPTION
## Summary

在 Kubernetes 自托管部署配置文档中新增 `global.settings.limits.maxMetricsPerCopy` 参数的说明。

## Changes

- **en/self_host/kubernetes/configuration.md**: 新增 `maxMetricsPerCopy` 参数文档（默认值 20000，实验复制操作的最大指标数限制）
- **zh/self_host/kubernetes/configuration.md**: 同上，中文版

## Testing

文档变更，无需测试。

## Notes

未找到markdown格式化方法，因此可能存在格式不规范的情况，如需修改请告知～